### PR TITLE
Update lwjgl and fix macos arm64 natives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,75 @@
 # hello_lwjgl
 
-How to get LWJGL3 working with Leiningen & Clojure.
+## How to get LWJGL3 working with Leiningen & Clojure.
+A series of examples of LWJGL in Clojure.
+Supports live code reloading in the REPL.
+Works with Mac ARM, Linux, (Windows?, Mac x86?)
 
-*Now with automatic downloads!*
 
-In [this pull
-request](https://github.com/rogerallen/hello_lwjgl/pull/8)
-[euccastro](https://github.com/euccastro) provides an elegant way to
-download the native libraries easily.  While I have some concern that
-this might break 32-bit compatibility, it would seem that there is
-less interest in maintaining that pathway.  So, I can delete the old,
-complicated instructions that were here and now you can just look at
-the top of project.clj and configure LWJGL3 to download & use the
-libraries & version you want in a very simple manner.
+
+## Standard Usage
+To run these examples, add the name of the example to the 'lein run' command in your console, (as the first arg)
+
+- **alpha** - a spinning triangle that uses OpenGL 1.1
+  * `> lein run alpha`
+- **beta** - a spinning triangle that uses OpenGL 3.2
+  * `> lein run beta`
+- **gamma** - A fullscreen spinning triangle that uses OpenGL 1.1, that can be moved with a keyboard. The triangle also rotates to follow the mouse.
+  * `> lein run gamma`
+
+
+## REPL Usage
+This is where the real power lies. You have the ability to live code reload using the REPL, and thus dynamically change the render, while your app is running. It's pretty neat :).
+
+If you want to take advantage of live reloading, your LWJGL app must run in a thread separate from the thread your REPL is running in, because the main loop blocks.
+
+Use an atom to communicate between threads by using reset! on the draw function (or associated logic) within the REPL thread, and dereference the draw function in your main opengl loop.[^1]
+See `alpha-live-reload/main` for an example.
+
+[^1]: https://stackoverflow.com/questions/38961679/how-to-inject-code-from-one-thread-to-another-in-clojure-for-live-opengl-editin
+
+
+### OSX Specifics
+For OSX: LWJGL must be called from the main thread, so start this project with
+```bash
+> lein run alpha-live-reload cider           
+Hello, Lightweight Java Game Library! V 3.3.1 build 7
+Running on macosx
+-- Main Thread: lwjgl
+-- Child Thread: nrepl
+Run example Alpha with live reloading
+Starting Cider Nrepl Server Port 7888
+OpenGL version: 2.1 Metal - 76.3
+``` 
+and connect to the nREPL in cider with `M-x cider-connect` on port 7888.
+
+This optional 2nd argument calls LWJGL in the main thread, and initiates an nREPL server in a child thread, which you can then connect to from CIDER. [^2]
+This is needed due to interactions between the GLFW and AWT window system and Mac OS X. [^3] [^4]
+
+
+Note: on other platforms (linux) you can run the nREPL in the main thread with `M-x cider-jack-in`, and call GLFW functions in a child thread (or in the same thread as the nREPL, but doing so blocks, and you lose live reload functionality).
+
+[^2]: Please note that you may need to adjust the cider-nrepl package version to match your local install.  It changes often.
+[^3]: See Issue #6 for details and thanks to @antoinevg for his efforts in figuring this out.
+[^4]: Also, it is no longer needed to add the Emacs cider-nrepl package into your ~/.lein/profiles.clj file. 
+
+
+
+
 
 ## Application Setup
 
-If you want to create your own application using Clojure & LWJGL, here's what I did:
+If you want to create your own application using Clojure & LWJGL, create an app with lein the standard way
 
 ```bash
-> lein new app hello_lwjgl
-> cd hello_lwjgl
+> lein new app [your-name-here]
+> cd [your-name-here]
 ```
+And copy over any relevant logic from this library. See project.clj and the source code for more info,
+it is imperative to do so for a complete understanding the behavior of this program.
 
-See project.clj and the source code for more info.  Hopefully it is easy to follow.
 
-## Usage
 
-All of these are very basic examples.
-
-### alpha
-A spinning triangle that uses OpenGL 1.1
-### beta
-A spinning triangle that uses OpenGL 3.2
-### gamma
-A fullscreen spinning triangle that uses OpenGL 1.1 and you can move
-with a keyboard.  The triangle also rotates to follow the mouse.
-
-To run these examples, just add the name to the lein run commandline.
-E.g. to run the 'alpha' test:
-
-```bash
-> lein run alpha
-```
-
-### REPL Usage
-
-Because of interations between the GLFW and AWT window system and Mac OS X, using the REPL on Mac OS X is a bit different than on PC/Linux.  On PC/Linux, I think you can just use `lein repl` as you would normally.  But, on Mac, we need to start the nREPL server ourselves in a separate thread.  See Issue #6 for details and thanks to @antoinevg for his efforts in figuring this out.
-
-For Mac OS X, you should add the Emacs cider-nrepl package into your ~/.lein/profiles.clj file in order to get a REPL working.  I'm not sure about other external tools, so for now cider-nrepl is the way to get a REPL on the Mac.  To start this, add `cider` after the name of the example.  E.g. `lein alpha cider` will create a cider-nrepl server and report this on startup.  Something like this:
-
-```
-> lein run alpha cider
-Hello, Lightweight Java Game Library! V 3.0.0b SNAPSHOT
-Run example Alpha
-Starting Cider Nrepl Server Port 7888
-OpenGL version: 2.1 NVIDIA-10.4.2 310.41.35f01
-```
-
-In emacs, use `M-x cider-connect` and use port 7888 to connect.  A repl pane shoudl open up.  Now, you can adjust the code live, for example, adjust the angle of the triangle.
-
-```
-user> (in-ns 'hello-lwjgl.alpha)
-#namespace[hello-lwjgl.alpha]
-hello-lwjgl.alpha> (swap! globals assoc :angle 0.0)
-```
-
-Please note that you may need to adjust the cider-nrepl package version to match your local install.  It changes often.
 
 ### Running from the commandline
 
@@ -86,6 +89,16 @@ Then you can run it with a commandline.
 
 ## Notes
 
+
+*Now with automatic downloads!*
+
+In [this pull request](https://github.com/rogerallen/hello_lwjgl/pull/8), [euccastro](https://github.com/euccastro) provides an elegant way to download the native libraries easily.
+While I have some concern that this might break 32-bit compatibility, it would seem that there is less interest in maintaining that pathway.
+So, I can delete the old, complicated instructions that were here and now you can just look at the top of project.clj and configure LWJGL3 to download & use the libraries & version you want in a very simple manner.
+
+--------------------------------------------------
+
+
 * found this helpful example: https://github.com/honeytree/clojure-lwjgl
 * found this discussion: https://groups.google.com/forum/#!msg/leiningen/MAFbNqDYT78/Ub2scaa4RCoJ
 * See this issue for some background. https://github.com/technomancy/leiningen/issues/898
@@ -94,6 +107,8 @@ Then you can run it with a commandline.
 
 ## License
 
-Copyright © 2013-2018 Roger Allen.
+Copyright © 2013-2022 Roger Allen.
 
 Distributed under the Eclipse Public License, the same as Clojure.
+
+

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
 (def LWJGL_NS "org.lwjgl")
 
 ;; Edit this to change the version.
-(def LWJGL_VERSION "3.1.5")
+(def LWJGL_VERSION "3.3.1")
 
 ;; Edit this to add/remove packages.
 (def LWJGL_MODULES ["lwjgl"
@@ -58,6 +58,17 @@
 (def no-natives? #{"lwjgl-egl" "lwjgl-jawt" "lwjgl-odbc"
                    "lwjgl-opencl" "lwjgl-vulkan"})
 
+
+
+(def no-natives-macos-arm64?
+  #{"lwjgl-openvr" "lwjgl-sse" "lwjgl-tootle"})
+
+
+
+;; this could probably be written in a more declarative way,
+;; but it works for this demo.
+;; For more robust customization options, visit
+;; https://www.lwjgl.org/customize
 (defn lwjgl-deps-with-natives []
   (apply concat
          (for [m LWJGL_MODULES]
@@ -65,9 +76,12 @@
              (into [prefix]
                    (if (no-natives? m)
                      []
-                     (for [p LWJGL_PLATFORMS]
+                     (for [p (if (no-natives-macos-arm64? m)
+                               LWJGL_PLATFORMS
+                               (conj LWJGL_PLATFORMS "macos-arm64"))]
                        (into prefix [:classifier (str "natives-" p)
                                      :native-prefix ""]))))))))
+
 
 (def all-dependencies
   (into ;; Add your non-LWJGL dependencies here

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,7 @@
 
 (def all-dependencies
   (into ;; Add your non-LWJGL dependencies here
-   '[[org.clojure/clojure "1.8.0"]]
+   '[[org.clojure/clojure "1.11.1"]]
    (lwjgl-deps-with-natives)))
 
 (defproject hello_lwjgl "0.4.0"

--- a/project.clj
+++ b/project.clj
@@ -85,7 +85,8 @@
 
 (def all-dependencies
   (into ;; Add your non-LWJGL dependencies here
-   '[[org.clojure/clojure "1.11.1"]]
+   '[[org.clojure/clojure "1.11.1"]
+     [cider/cider-nrepl "0.28.6"]]
    (lwjgl-deps-with-natives)))
 
 (defproject hello_lwjgl "0.4.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(require 'leiningen.core.eval)
+(require 'leiningen.core.utils)
 
 ;; per-os jvm-opts code cribbed from Overtone
 (def JVM-OPTS
@@ -9,7 +9,10 @@
 
 (defn jvm-opts
   "Return a complete vector of jvm-opts for the current os."
-  [] (let [os (leiningen.core.eval/get-os)]
+  ;; (leiningen.core.utils/get-os) is preferred over 
+  ;; (System/getProperty "os.name"), its output is a keyword contained within
+  ;; #{:macosx :linux :windows}
+  [] (let [os (leiningen.core.utils/get-os)]
        (vec (set (concat (get JVM-OPTS :common)
                          (get JVM-OPTS os))))))
 
@@ -85,7 +88,8 @@
 
 (def all-dependencies
   (into ;; Add your non-LWJGL dependencies here
-   '[[org.clojure/clojure "1.11.1"]]
+   '[[org.clojure/clojure "1.11.1"]
+     [leiningen "2.9.10"]]
    (lwjgl-deps-with-natives)))
 
 (defproject hello_lwjgl "0.4.0"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
 ;; per-os jvm-opts code cribbed from Overtone
 (def JVM-OPTS
   {:common   []
-   :macosx   ["-XstartOnFirstThread" "-Djava.awt.headless=true"]
+   :macosx   ["-XstartOnFirstThread"]
    :linux    []
    :windows  []})
 

--- a/src/hello_lwjgl/alpha.clj
+++ b/src/hello_lwjgl/alpha.clj
@@ -118,3 +118,4 @@
     (GLFW/glfwDestroyWindow (:window @globals))
     (finally
       (GLFW/glfwTerminate))))
+

--- a/src/hello_lwjgl/alpha_live_reload.clj
+++ b/src/hello_lwjgl/alpha_live_reload.clj
@@ -54,7 +54,7 @@
     (GLFW/glfwMakeContextCurrent (:window @globals))
     ;; call (glfwSwapInterval 0) to temp fix lag while moving window on linux
     ;; apparently this is an issue with nvidia drivers
-    (GLFW/glfwSwapInterval 0)
+    (GLFW/glfwSwapInterval 1)
     (GLFW/glfwShowWindow (:window @globals))))
 
 (defn init-gl

--- a/src/hello_lwjgl/alpha_live_reload.clj
+++ b/src/hello_lwjgl/alpha_live_reload.clj
@@ -1,4 +1,4 @@
-(ns hello-lwjgl.alpha
+(ns hello-lwjgl.alpha-live-reload
   (:import (org.lwjgl.opengl GL GL11)
            (org.lwjgl.glfw GLFW GLFWErrorCallback GLFWKeyCallback)))
 
@@ -52,7 +52,9 @@
      (/ (- (.width vidmode) width) 2)
      (/ (- (.height vidmode) height) 2))
     (GLFW/glfwMakeContextCurrent (:window @globals))
-    (GLFW/glfwSwapInterval 1)
+    ;; call (glfwSwapInterval 0) to temp fix lag while moving window on linux
+    ;; apparently this is an issue with nvidia drivers
+    (GLFW/glfwSwapInterval 0)
     (GLFW/glfwShowWindow (:window @globals))))
 
 (defn init-gl
@@ -67,9 +69,12 @@
   (GL11/glMatrixMode GL11/GL_MODELVIEW))
 
 
-(defn draw
-  []
-  (let [{:keys [width height angle]} @globals
+(def hot-draw (atom (fn [])))
+
+(reset!
+ hot-draw
+ (fn []
+   (let [{:keys [width height angle]} @globals
         w2 (/ width 2.0)
         h2 (/ height 2.0)]
     (GL11/glClear (bit-or GL11/GL_COLOR_BUFFER_BIT  GL11/GL_DEPTH_BUFFER_BIT))
@@ -85,7 +90,9 @@
       (GL11/glVertex2i -50 86.6)
       (GL11/glColor3f 0.0 0.0 1.0)
       (GL11/glVertex2i -50 -86.6))
-    (GL11/glEnd)))
+    (GL11/glEnd))
+   ))
+
 
 (defn update-globals
   []
@@ -104,13 +111,13 @@
   []
   (while (not (GLFW/glfwWindowShouldClose (:window @globals)))
     (update-globals)
-    (draw) 
+    (@hot-draw) 
     (GLFW/glfwSwapBuffers (:window @globals))
     (GLFW/glfwPollEvents)))
 
 (defn main
   []
-  (println "Run example Alpha")
+  (println "Run example Alpha with live reloading")
   (try
     (init-window 800 600 "alpha")
     (init-gl)

--- a/src/hello_lwjgl/core.clj
+++ b/src/hello_lwjgl/core.clj
@@ -1,5 +1,7 @@
 (ns hello-lwjgl.core
-  (:require [hello-lwjgl.alpha :as alpha]
+  (:require [leiningen.core.utils]
+            [hello-lwjgl.alpha :as alpha]
+            [hello-lwjgl.alpha-live-reload :as alpha-live-reload]
             [hello-lwjgl.beta  :as beta]
             [hello-lwjgl.gamma :as gamma]
             ;;[hello-lwjgl.omega :as omega]
@@ -7,9 +9,14 @@
   (:import (org.lwjgl Version))
   (:gen-class))
 
+
 ;; ======================================================================
-(defn start-cider-nrepl
+(defn start-cider-nrepl-in-new-thread
   []
+  ;; for osx, you are required to run glfw from the main thread,
+  ;; thus we must run the repl from a child thread for live code reloading.
+  ;; You can connect to this child thread repl with cider by M-x cider-connect
+  ;; instead of the usual M-x cider-jack-in
   (.start (Thread. (fn []
       (println "Starting Cider Nrepl Server Port 7888")
       (load-string (str "(require '[clojure.tools.nrepl.server :as nrepl-server])"
@@ -17,14 +24,78 @@
                         "(nrepl-server/start-server :port 7888 :handler cider/cider-nrepl-handler)"))))))
 
 ;; ======================================================================
+
+
+;; added mutlimethod for easy future extensibility
+(defmulti main-dispatch identity)
+
+
+(defmethod main-dispatch "alpha" [_]
+  (alpha/main))
+
+(defmethod main-dispatch "alpha-live-reload" [_]
+  (alpha-live-reload/main))
+
+(defmethod main-dispatch "beta"  [_]
+  (beta/main))
+(defmethod main-dispatch "gamma" [_]
+  (gamma/main))
+
+(defmethod main-dispatch "omega" [_]
+  ((comment (omega/main))
+   (println "omega is not yet implemented")))
+
+(defmethod main-dispatch :default [_]
+  (throw (IllegalArgumentException. "Unknown Parameter")))
+
+
+
+
 (defn -main
   [& args]
-  (println "Hello, Lightweight Java Game Library! V" (Version/getVersion))
-  (when (= "cider" (second args))
-    (start-cider-nrepl))
-  (cond
-   (= "alpha" (first args)) (alpha/main)
-   (= "beta"  (first args)) (beta/main)
-   (= "gamma" (first args)) (gamma/main)
-   ;;(= "omega" (first args)) (omega/main)
-   :else (alpha/main)))
+  (let [demo-name              (first args)
+        nrepl-in-new-thread?   (= "cider" (second args))
+        os                     (leiningen.core.utils/get-os)]
+    
+    (println "Hello, Lightweight Java Game Library! V" (Version/getVersion))
+    (println "Running on" (name os))
+    (case os
+      
+      ;; required for osx: -lwjgl from main thread
+      ;;                   -repl from child thread
+      :macosx
+      (do (println    "-- Main Thread: lwjgl")
+          (when nrepl-in-new-thread?
+            (println  "-- Child Thread: nrepl")
+            (start-cider-nrepl-in-new-thread))
+          (main-dispatch demo-name))
+      
+      ;; else: start lwjgl in child thread
+      (do (println "-- Main Thread: nrepl")
+          (println "-- Child Thread: lwjgl")
+
+          (.start (Thread. (fn [] (main-dispatch demo-name))))))))
+
+
+
+(comment
+
+  ;; You have the ability to live reload code using the repl,
+  ;; and thus dynamically change the render, while your app is running.
+  ;; It's pretty fun :).
+  
+  ;; If you want to take advantage of live reloading, your opengl app must
+  ;; run in a thread separate from the thread your repl is running in.
+  ;; Use an atom to communicate between threads by using reset! on the draw
+  ;; function (or associated logic) within the repl thread, and dereference
+  ;; the draw function in your main opengl loop.
+  ;; See alpha-live-reload/main for an example.
+
+  ;; remember to use
+  ;; (.start (Thread. (fn []))) instead of  (future & body)
+  ;; for example, call the following within cider
+  ;; to be able to play with live reloading
+  (.start (Thread. (fn [] (alpha-live-reload/main))))
+  ;; and try redefining the hot-draw atom within that namespace in your repl
+  
+  )

--- a/src/hello_lwjgl/core.clj
+++ b/src/hello_lwjgl/core.clj
@@ -95,19 +95,6 @@
 
   ;; --- Live Code Reloading --- 
 
-  ;; You have the ability to live reload code using the repl,
-  ;; and thus dynamically change the render, while your app is running.
-  ;; It's pretty neat :).
-  
-  ;; If you want to take advantage of live reloading, your opengl app must
-  ;; run in a thread separate from the thread your repl is running in.
-  
-  ;; Use an atom to communicate between threads by using reset! on the draw
-  ;; function (or associated logic) within the repl thread, and dereference
-  ;; the draw function in your main opengl loop.
-  ;; See alpha-live-reload/main for an example.
-
-  ;; remember to use
   ;; (.start (Thread. (fn []))) instead of  (future & body)
   ;; for example, call the following within cider
   ;; to be able to play with live reloading
@@ -117,9 +104,5 @@
   ;; For OSX: lwjgl must be called from the main thread, so
   ;; start this project with 'lein run alpha-live-reload cider' and connect
   ;; to the repl in cider with M-x cider-connect.
-
-  ;; Reference
-  ;; https://stackoverflow.com/questions/38961679/how-to-inject-code-from-one-thread-to-another-in-clojure-for-live-opengl-editin
-  
   )
 

--- a/src/hello_lwjgl/core.clj
+++ b/src/hello_lwjgl/core.clj
@@ -6,28 +6,36 @@
             [hello-lwjgl.gamma :as gamma]
             ;;[hello-lwjgl.omega :as omega]
             )
-  (:import (org.lwjgl Version))
+  (:import [org.lwjgl Version])
   (:gen-class))
 
 
-;; ======================================================================
+
+;; ==================================================
+;; OSX glfw + repl compatability hack
+
 (defn start-cider-nrepl-in-new-thread
+  "Required on OSX -- glfw MUST be run from main thread, so this fn creates a
+  repl on a child thread for live code reloading.
+  Connect with cider by M-x cider-connect instead of M-x cider-jack-in"
   []
-  ;; for osx, you are required to run glfw from the main thread,
-  ;; thus we must run the repl from a child thread for live code reloading.
-  ;; You can connect to this child thread repl with cider by M-x cider-connect
-  ;; instead of the usual M-x cider-jack-in
-  (.start (Thread. (fn []
-                     (println "Starting Cider Nrepl Server Port 7888")
-                     (load-string (str ;; "(require '[clojure.tools.nrepl.server :as nrepl-server])"
-                                       "(require '[nrepl.server :as nrepl-server])"
-                                       "(require '[cider.nrepl :as cider])"
-                                       "(nrepl-server/start-server :port 7888 :handler cider/cider-nrepl-handler)"))))))
-
-;; ======================================================================
+  (.start
+   (Thread.
+    (fn []
+      (println "Starting Cider Nrepl Server Port 7888")
+      (eval `(do
+               (require 'nrepl.server)
+               (require 'cider.nrepl)
+               (nrepl.server/start-server
+                :port 7888
+                :handler cider.nrepl/cider-nrepl-handler)))))))
 
 
-;; added mutlimethod for easy future extensibility
+
+
+;; ==================================================
+;; Dispatch multimethod for easy future extensibility
+
 (defmulti main-dispatch identity)
 
 
@@ -50,6 +58,10 @@
   (throw (IllegalArgumentException. "Unknown Parameter")))
 
 
+
+
+;; ==================================================
+;; Main entry for program
 
 
 (defn -main
@@ -81,12 +93,15 @@
 
 (comment
 
+  ;; --- Live Code Reloading --- 
+
   ;; You have the ability to live reload code using the repl,
   ;; and thus dynamically change the render, while your app is running.
-  ;; It's pretty fun :).
+  ;; It's pretty neat :).
   
   ;; If you want to take advantage of live reloading, your opengl app must
   ;; run in a thread separate from the thread your repl is running in.
+  
   ;; Use an atom to communicate between threads by using reset! on the draw
   ;; function (or associated logic) within the repl thread, and dereference
   ;; the draw function in your main opengl loop.
@@ -98,5 +113,13 @@
   ;; to be able to play with live reloading
   (.start (Thread. (fn [] (alpha-live-reload/main))))
   ;; and try redefining the hot-draw atom within that namespace in your repl
+
+  ;; For OSX: lwjgl must be called from the main thread, so
+  ;; start this project with 'lein run alpha-live-reload cider' and connect
+  ;; to the repl in cider with M-x cider-connect.
+
+  ;; Reference
+  ;; https://stackoverflow.com/questions/38961679/how-to-inject-code-from-one-thread-to-another-in-clojure-for-live-opengl-editin
   
   )
+

--- a/src/hello_lwjgl/core.clj
+++ b/src/hello_lwjgl/core.clj
@@ -11,10 +11,11 @@
 (defn start-cider-nrepl
   []
   (.start (Thread. (fn []
-      (println "Starting Cider Nrepl Server Port 7888")
-      (load-string (str "(require '[clojure.tools.nrepl.server :as nrepl-server])"
-                        "(require '[cider.nrepl :as cider])"
-                        "(nrepl-server/start-server :port 7888 :handler cider/cider-nrepl-handler)"))))))
+                     (println "Starting Cider Nrepl Server Port 7888")
+                     (load-string (str ;; "(require '[clojure.tools.nrepl.server :as nrepl-server])"
+                                       "(require '[nrepl.server :as nrepl-server])"
+                                       "(require '[cider.nrepl :as cider])"
+                                       "(nrepl-server/start-server :port 7888 :handler cider/cider-nrepl-handler)"))))))
 
 ;; ======================================================================
 (defn -main


### PR DESCRIPTION
- updated lwjgl to latest (3.3.1)
- added dependencies for macos-arm64 (now runs on M1 Macbooks without error)
- updated clojure to latest (1.11.1)